### PR TITLE
Feat: Guard updates

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "name": "Debug Router Tests",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "Build: Navs.Tests.fsproj",
+      "preLaunchTask": "build:tests",
       "program": "${workspaceFolder}/tests/Navs.Tests/bin/Debug/net8.0/Navs.Tests.dll",
       "args": [],
       "cwd": "${workspaceFolder}",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,20 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "type": "msbuild",
-      "problemMatcher": ["$msCompile"],
-      "group": "build",
-      "label": "Build: Navs.Tests.fsproj",
-      "detail": "Build the Navs.Tests.fsproj project using dotnet build"
+      "command": "dotnet",
+      "label": "build:tests",
+      "type": "shell",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$msCompile",
+      "args": [
+        "build",
+        "${workspaceFolder}/tests/Navs.Tests/Navs.Tests.fsproj",
+        "-f",
+        "net8.0"
+      ]
     }
   ]
 }

--- a/src/Navs/DSL.Interop.fs
+++ b/src/Navs/DSL.Interop.fs
@@ -14,11 +14,7 @@ do ()
 type Route =
 
   static member inline Define<'View>
-    (
-      name,
-      path,
-      getContent: Func<RouteContext, INavigable<'View>, 'View>
-    ) =
+    (name, path, getContent: Func<RouteContext, INavigable<'View>, 'View>) =
     {
       name = name
       pattern = path
@@ -46,16 +42,22 @@ type Route =
       cacheStrategy = Cache
     }
 
+
+[<RequireQualifiedAccess>]
+module Guard =
+  let inline Continue () = Continue
+  let inline Stop () = Stop
+
+  let inline Redirect url = Redirect url
+
+
 [<Extension>]
 type RouteDefinitionExtensions =
 
 
   [<Extension>]
   static member inline Child<'View>
-    (
-      routeDef: RouteDefinition<'View>,
-      child: RouteDefinition<'View>
-    ) =
+    (routeDef: RouteDefinition<'View>, child: RouteDefinition<'View>) =
     Route.child child routeDef
 
   [<Extension>]
@@ -71,7 +73,12 @@ type RouteDefinitionExtensions =
     (
       routeDef: RouteDefinition<'View>,
       [<ParamArray>] guards:
-        Func<RouteContext, CancellationToken, Task<bool>> array
+        Func<
+          RouteContext,
+          INavigable<'View>,
+          CancellationToken,
+          Task<GuardResponse>
+         > array
     ) =
     {
       routeDef with
@@ -87,7 +94,12 @@ type RouteDefinitionExtensions =
     (
       routeDef: RouteDefinition<'View>,
       [<ParamArray>] guards:
-        Func<RouteContext, CancellationToken, Task<bool>> array
+        Func<
+          RouteContext,
+          INavigable<'View>,
+          CancellationToken,
+          Task<GuardResponse>
+         > array
     ) =
     {
       routeDef with

--- a/src/Navs/DSL.Interop.fsi
+++ b/src/Navs/DSL.Interop.fsi
@@ -32,6 +32,26 @@ type Route =
     name: string * path: string * getContent: Func<RouteContext, INavigable<'View>, CancellationToken, Task<'View>> ->
       RouteDefinition<'View>
 
+/// <summary>
+/// A module that provides functions for route guard responses
+/// </summary>
+[<RequireQualifiedAccess>]
+module Guard =
+
+  /// <summary>
+  /// A guard response that indicates that the navigation should continue
+  /// </summary>
+  val inline Continue: unit -> GuardResponse
+
+  /// <summary>
+  /// A guard response that indicates that the navigation should stop and fail the navigation
+  /// </summary>
+  val inline Stop: unit -> GuardResponse
+
+  /// <summary>
+  /// A guard response that indicates that the navigation should stop and redirect to the specified URL
+  /// </summary>
+  val inline Redirect: string -> GuardResponse
 
 /// <summary>
 /// Extensions for a builder-like API for defining routes in the application
@@ -57,7 +77,8 @@ type RouteDefinitionExtensions =
   /// </summary>
   [<Extension>]
   static member inline CanActivate:
-    routeDef: RouteDefinition<'View> * [<ParamArray>] guards: Func<RouteContext, CancellationToken, Task<bool>> array ->
+    routeDef: RouteDefinition<'View> *
+    [<ParamArray>] guards: Func<RouteContext, INavigable<'View>, CancellationToken, Task<GuardResponse>> array ->
       RouteDefinition<'View>
 
   /// <summary>
@@ -65,7 +86,8 @@ type RouteDefinitionExtensions =
   /// </summary>
   [<Extension>]
   static member inline CanDeactivate:
-    routeDef: RouteDefinition<'View> * [<ParamArray>] guards: Func<RouteContext, CancellationToken, Task<bool>> array ->
+    routeDef: RouteDefinition<'View> *
+    [<ParamArray>] guards: Func<RouteContext, INavigable<'View>, CancellationToken, Task<GuardResponse>> array ->
       RouteDefinition<'View>
 
   /// <summary>

--- a/src/Navs/DSL.fs
+++ b/src/Navs/DSL.fs
@@ -96,7 +96,8 @@ type Route =
 
 module Route =
   let inline canActivateTask
-    ([<InlineIfLambda>] guard: RouteContext -> CancellationToken -> Task<bool>)
+    ([<InlineIfLambda>] guard:
+      RouteContext -> INavigable<_> -> CancellationToken -> Task<GuardResponse>)
     definition
     : RouteDefinition<_> =
     {
@@ -105,20 +106,25 @@ module Route =
     }
 
   let inline canActivate
-    ([<InlineIfLambda>] guard: RouteContext -> Async<bool>)
+    ([<InlineIfLambda>] guard:
+      RouteContext -> INavigable<_> -> Async<GuardResponse>)
     definition
     : RouteDefinition<_> =
     {
       definition with
           canActivate =
-            (fun ctx token ->
-              Async.StartImmediateAsTask(guard ctx, cancellationToken = token)
+            (fun ctx nav token ->
+              Async.StartImmediateAsTask(
+                guard ctx nav,
+                cancellationToken = token
+              )
             )
             :: definition.canActivate
     }
 
   let inline canDeactivateTask
-    ([<InlineIfLambda>] guard: RouteContext -> CancellationToken -> Task<bool>)
+    ([<InlineIfLambda>] guard:
+      RouteContext -> INavigable<_> -> CancellationToken -> Task<GuardResponse>)
     definition
     : RouteDefinition<_> =
     {
@@ -127,14 +133,18 @@ module Route =
     }
 
   let inline canDeactivate
-    ([<InlineIfLambda>] guard: RouteContext -> Async<bool>)
+    ([<InlineIfLambda>] guard:
+      RouteContext -> INavigable<_> -> Async<GuardResponse>)
     definition
     : RouteDefinition<_> =
     {
       definition with
           canDeactivate =
-            (fun ctx token ->
-              Async.StartImmediateAsTask(guard ctx, cancellationToken = token)
+            (fun ctx nav token ->
+              Async.StartImmediateAsTask(
+                guard ctx nav,
+                cancellationToken = token
+              )
             )
             :: definition.canDeactivate
     }

--- a/src/Navs/DSL.fsi
+++ b/src/Navs/DSL.fsi
@@ -72,7 +72,7 @@ module Route =
   /// <param name="definition">The route definition</param>
   /// <returns>The route definition with the guard added</returns>
   val inline canActivateTask:
-    [<InlineIfLambda>] guard: (RouteContext -> CancellationToken -> Task<bool>) ->
+    [<InlineIfLambda>] guard: (RouteContext -> INavigable<'a> -> CancellationToken -> Task<GuardResponse>) ->
     definition: RouteDefinition<'a> ->
       RouteDefinition<'a>
 
@@ -83,7 +83,9 @@ module Route =
   /// <param name="definition">The route definition</param>
   /// <returns>The route definition with the guard added</returns>
   val inline canActivate:
-    [<InlineIfLambda>] guard: (RouteContext -> Async<bool>) -> definition: RouteDefinition<'a> -> RouteDefinition<'a>
+    [<InlineIfLambda>] guard: (RouteContext -> INavigable<'a> -> Async<GuardResponse>) ->
+    definition: RouteDefinition<'a> ->
+      RouteDefinition<'a>
 
   /// <summary>
   /// A Task function to define if a route can be deactivated.
@@ -92,7 +94,7 @@ module Route =
   /// <param name="definition">The route definition</param>
   /// <returns>The route definition with the guard added</returns>
   val inline canDeactivateTask:
-    [<InlineIfLambda>] guard: (RouteContext -> CancellationToken -> Task<bool>) ->
+    [<InlineIfLambda>] guard: (RouteContext -> INavigable<'a> -> CancellationToken -> Task<GuardResponse>) ->
     definition: RouteDefinition<'a> ->
       RouteDefinition<'a>
 
@@ -103,4 +105,6 @@ module Route =
   /// <param name="definition">The route definition</param>
   /// <returns>The route definition with the guard added</returns>
   val inline canDeactivate:
-    [<InlineIfLambda>] guard: (RouteContext -> Async<bool>) -> definition: RouteDefinition<'a> -> RouteDefinition<'a>
+    [<InlineIfLambda>] guard: (RouteContext -> INavigable<'a> -> Async<GuardResponse>) ->
+    definition: RouteDefinition<'a> ->
+      RouteDefinition<'a>

--- a/src/Navs/Router.fs
+++ b/src/Navs/Router.fs
@@ -2,7 +2,6 @@ namespace Navs.Router
 
 open System
 open System.Collections.Generic
-open System.Threading
 open System.Runtime.InteropServices
 
 open FsToolkit.ErrorHandling
@@ -29,7 +28,9 @@ type RoutingEnv<'View> = {
   state: cval<NavigationState>
   viewCache: cmap<string, ActiveRouteParams list * UrlInfo * 'View>
   activeRoute:
-    cval<voption<(RouteContext * (RouteGuard * RouteDefinition<'View>) list)>>
+    cval<
+      voption<(RouteContext * (RouteGuard<'View> * RouteDefinition<'View>) list)>
+     >
   content: cval<voption<'View>>
 }
 
@@ -44,14 +45,17 @@ type ParamResoluton<'View> = {
 [<NoEquality; NoComparison>]
 type RouteResolution<'View> = {
   view: 'View
-  canDeactivateGuards: (RouteGuard * RouteDefinition<'View>) list
+  canDeactivateGuards: (RouteGuard<'View> * RouteDefinition<'View>) list
 }
 
 [<Struct; NoComparison>]
 type Guards<'View> = {
-  canActivate: list<RouteGuard * RouteDefinition<'View>>
-  canDeactivate: list<RouteGuard * RouteDefinition<'View>>
+  canActivate: list<RouteGuard<'View> * RouteDefinition<'View>>
+  canDeactivate: list<RouteGuard<'View> * RouteDefinition<'View>>
 }
+
+[<Struct; NoComparison>]
+type Redirection = { from: string; target: string }
 
 
 module RouteTracks =
@@ -83,10 +87,12 @@ module RouteTracks =
     (track: RouteDefinition<'View>)
     =
     let queue =
-      Queue<string *
-      RouteTrack<'View> voption *
-      RouteDefinition<'View> *
-      RouteTrack<'View> list>()
+      Queue<
+        string *
+        RouteTrack<'View> voption *
+        RouteDefinition<'View> *
+        RouteTrack<'View> list
+       >()
 
     let result = ResizeArray<RouteTrack<'View>>()
 
@@ -134,10 +140,8 @@ module RouteTracks =
 module RoutingEnv =
 
   let get<'View>
-    (
-      routes: RouteDefinition<'View> seq,
-      splash: (unit -> 'View) option
-    ) =
+    (routes: RouteDefinition<'View> seq, splash: (unit -> 'View) option)
+    =
     let routes = RouteTracks.fromDefinitions routes
 
     {
@@ -148,8 +152,6 @@ module RoutingEnv =
       content =
         cval(splash |> ValueOption.ofOption |> ValueOption.map(fun f -> f()))
     }
-
-
 
 module Result =
   let inline requireValueSome (msg: string) (value: 'a voption) =
@@ -178,7 +180,6 @@ module RouteInfo =
           )
         | _ -> None
       )
-
 
   let digUpToRoot (track: RouteTrack<'View>) =
     let queue = Queue<RouteTrack<'View>>()
@@ -236,8 +237,8 @@ module RouteInfo =
 
   let extractGuards (activeGraph: RouteTrack<'View> seq) =
 
-    let canActivate = Stack<RouteGuard * RouteDefinition<'View>>()
-    let canDeactivate = Queue<RouteGuard * RouteDefinition<'View>>()
+    let canActivate = Stack<RouteGuard<'View> * RouteDefinition<'View>>()
+    let canDeactivate = Queue<RouteGuard<'View> * RouteDefinition<'View>>()
 
     activeGraph
     |> Seq.iter(fun route ->
@@ -262,8 +263,9 @@ module RouteInfo =
 module Navigable =
 
   let runGuards<'View>
-    (onFalsePredicate: string -> NavigationError<'View>)
-    (guards: (RouteGuard * RouteDefinition<'View>) list)
+    (navigable: INavigable<'View>)
+    (onStop: string -> NavigationError<'View>)
+    (guards: (RouteGuard<'View> * RouteDefinition<'View>) list)
     nextContext
     =
     async {
@@ -271,30 +273,40 @@ module Navigable =
 
       return!
         guards
-        |> List.traverseAsyncResultM(fun (guard, definition) ->
+        |> List.traverseAsyncResultM(fun (guard, definition) -> asyncResult {
           if token.IsCancellationRequested then
-            AsyncResult.error NavigationCancelled
+            return! Error NavigationCancelled
           else
-            guard nextContext token
-            |> Async.AwaitTask
-            |> AsyncResult.requireTrue(onFalsePredicate definition.name)
-        )
+            let! result = guard nextContext navigable token |> Async.AwaitTask
+
+            match result with
+            | Continue -> return ()
+            | Stop -> return! Error(onStop definition.name)
+            | Redirect url -> return! Error(GuardRedirect url)
+
+        })
         |> AsyncResult.ignore
     }
 
-  let canDeactivate (activeContext) = asyncResult {
+  let canDeactivate (nav: ref<INavigable<_>>) activeContext = async {
     match activeContext |> AVal.force with
+    | ValueNone -> return Ok()
     | ValueSome(activeContext, activeGuards) ->
 
-      do! runGuards CantDeactivate activeGuards activeContext
+      let! result =
+        runGuards nav.Value CantDeactivate activeGuards activeContext
 
-    | ValueNone -> ()
+      match result with
+      | Error(GuardRedirect _) ->
+        return Error(CantDeactivate activeContext.path)
+      | value -> return value
   }
 
-  let canActivate (nextContext, activeRouteNodes) = asyncResult {
+  let canActivate (nav: ref<INavigable<_>>) (nextContext, activeRouteNodes) = asyncResult {
     let guards = RouteInfo.extractGuards activeRouteNodes
 
-    do! runGuards CantActivate guards.canActivate nextContext
+    do! runGuards nav.Value CantActivate guards.canActivate nextContext
+
     return guards
   }
 
@@ -376,15 +388,28 @@ module Navigable =
     }
   }
 
+  type private CanDeactivateExecutor<'View> =
+    (voption<RouteContext * list<RouteGuard<'View> * RouteDefinition<'View>>>) cval
+      -> Async<Result<unit, NavigationError<'View>>>
+
+  type private CanActivateExecutor<'View> =
+    RouteContext * seq<RouteTrack<'View>>
+      -> Async<Result<Guards<'View>, NavigationError<'View>>>
+
+  type private ResolveViewExecutor<'View> =
+    ParamResoluton<'View> -> Async<Result<'View, NavigationError<'View>>>
+
   let navigateByUrl
     (
       routingEnv,
       resolveParams,
-      resolveView:
-        ParamResoluton<'View> -> Async<Result<'View, NavigationError<'View>>>
+      resolveView: ResolveViewExecutor<'View>,
+      canActivate: CanActivateExecutor<'View>,
+      canDeactivate: CanDeactivateExecutor<'View>
     ) =
     fun (url: string) -> asyncResult {
       let! token = Async.CancellationToken
+
       // 1. Can Deactivate
       do! canDeactivate routingEnv.activeRoute
 
@@ -431,14 +456,22 @@ module Navigable =
         )
     }
 
-  let navigateByName routingEnv nav =
+  let navigateByName routingEnv nav redirectionStack =
     fun name routeParams -> asyncResult {
-
       let tryGetFromCache = tryGetFromCache routingEnv.viewCache
       let resolveParams = resolveParams routingEnv
       let resolveView = resolveView tryGetFromCache nav
+      let canActivate = canActivate nav
+      let canDeactivate = canDeactivate nav
 
-      let navigateByUrl = navigateByUrl(routingEnv, resolveParams, resolveView)
+      let navigateByUrl =
+        navigateByUrl(
+          routingEnv,
+          resolveParams,
+          resolveView,
+          canActivate,
+          canDeactivate
+        )
 
       let routeParams: IReadOnlyDictionary<string, obj> =
         routeParams
@@ -464,7 +497,17 @@ module Navigable =
     let tryGetFromCache = tryGetFromCache routingEnv.viewCache
     let resolveParams = resolveParams routingEnv
     let resolveView = resolveView tryGetFromCache navigable
-    let navigateByUrl = navigateByUrl(routingEnv, resolveParams, resolveView)
+    let canActivate = canActivate navigable
+    let canDeactivate = canDeactivate navigable
+
+    let navigateByUrl =
+      navigateByUrl(
+        routingEnv,
+        resolveParams,
+        resolveView,
+        canActivate,
+        canDeactivate
+      )
 
     navigable.Value <-
       { new INavigable<'View> with
@@ -474,15 +517,51 @@ module Navigable =
           override _.StateSnapshot = routingEnv.state |> AVal.force
 
           override _.Navigate(url, ?cancellationToken) = task {
+            let redirectionStack = Stack<Redirection>()
+
             try
               transact(fun _ -> routingEnv.state.Value <- Navigating)
 
               try
-                return!
+                let! result =
                   Async.StartImmediateAsTask(
                     navigateByUrl url,
                     ?cancellationToken = cancellationToken
                   )
+
+                let mutable lastResult = result
+
+                match result with
+                | Ok _ -> ()
+                | Error(GuardRedirect redirectTo) ->
+                  redirectionStack.Push({ from = url; target = redirectTo })
+                | Error _ -> redirectionStack.Clear()
+
+                while redirectionStack.Count > 0 do
+                  let { from = from; target = target } = redirectionStack.Pop()
+
+                  let! result =
+                    Async.StartImmediateAsTask(
+                      navigateByUrl target,
+                      ?cancellationToken = cancellationToken
+                    )
+
+                  lastResult <- result
+
+                  match result with
+                  | Ok _ -> ()
+                  | Error(GuardRedirect redirectTo) ->
+
+                    if target = redirectTo then
+                      ()
+                    else
+                      redirectionStack.Push(
+                        { from = from; target = redirectTo }
+                      )
+                  | Error _ -> redirectionStack.Clear()
+
+                return lastResult
+
               with
               | :? TaskCanceledException
               | :? OperationCanceledException ->
@@ -499,15 +578,57 @@ module Navigable =
           }
 
           override _.NavigateByName(name, ?routeParams, ?cancellationToken) = task {
+            let redirectionStack = Stack<Redirection>()
+
             try
               transact(fun _ -> routingEnv.state.Value <- Navigating)
 
               try
-                return!
+                let! result =
                   Async.StartImmediateAsTask(
-                    navigateByName routingEnv navigable name routeParams,
+                    navigateByName
+                      routingEnv
+                      navigable
+                      redirectionStack
+                      name
+                      routeParams,
                     ?cancellationToken = cancellationToken
                   )
+
+                let mutable lastResult = result
+
+                match result with
+                | Ok _ -> ()
+                | Error(GuardRedirect redirectTo) ->
+                  printfn "Redirecting to %s" redirectTo
+                  redirectionStack.Push({ from = name; target = redirectTo })
+                | Error _ -> redirectionStack.Clear()
+
+                while redirectionStack.Count > 0 do
+                  let { from = from; target = target } = redirectionStack.Pop()
+
+                  let! result =
+                    Async.StartImmediateAsTask(
+                      navigateByUrl target,
+                      ?cancellationToken = cancellationToken
+                    )
+
+                  lastResult <- result
+
+                  match result with
+                  | Ok _ -> ()
+                  | Error(GuardRedirect redirectTo) ->
+                    printfn "Redirecting to %s" redirectTo
+
+                    if from = from && target = redirectTo then
+                      ()
+                    else
+                      redirectionStack.Push(
+                        { from = from; target = redirectTo }
+                      )
+                  | Error _ -> redirectionStack.Clear()
+
+                return lastResult
               with
               | :? TaskCanceledException
               | :? OperationCanceledException ->

--- a/src/Navs/Router.fsi
+++ b/src/Navs/Router.fsi
@@ -29,7 +29,7 @@ type internal RoutingEnv<'View> =
   { routes: RouteTrack<'View> seq
     state: cval<NavigationState>
     viewCache: cmap<string, ActiveRouteParams list * UrlInfo * 'View>
-    activeRoute: cval<voption<(RouteContext * (RouteGuard * RouteDefinition<'View>) list)>>
+    activeRoute: cval<voption<(RouteContext * (RouteGuard<'View> * RouteDefinition<'View>) list)>>
     content: cval<voption<'View>> }
 
 

--- a/src/Navs/Types.fs
+++ b/src/Navs/Types.fs
@@ -25,6 +25,7 @@ type NavigationError<'View> =
   | NavigationFailed of message: string
   | CantDeactivate of deactivatedRoute: string
   | CantActivate of activatedRoute: string
+  | GuardRedirect of redirectTo: string
 
 [<Struct>]
 type NavigationState =
@@ -61,7 +62,14 @@ type IRouter<'View> =
   abstract member ContentSnapshot: 'View voption
 
 
-type RouteGuard = RouteContext -> CancellationToken -> Task<bool>
+[<Struct>]
+type GuardResponse =
+  | Continue
+  | Stop
+  | Redirect of url: string
+
+type RouteGuard<'View> =
+  RouteContext -> INavigable<'View> -> CancellationToken -> Task<GuardResponse>
 
 type GetView<'View> =
   RouteContext -> INavigable<'View> -> CancellationToken -> Task<'View>
@@ -82,9 +90,9 @@ type RouteDefinition<'View> = {
   [<CompiledName "Children">]
   children: RouteDefinition<'View> list
   [<CompiledName "CanActivate">]
-  canActivate: RouteGuard list
+  canActivate: RouteGuard<'View> list
   [<CompiledName "CanDeactivate">]
-  canDeactivate: RouteGuard list
+  canDeactivate: RouteGuard<'View> list
   [<CompiledName "CacheStrategy">]
   cacheStrategy: CacheStrategy
 }

--- a/src/Navs/Types.fsi
+++ b/src/Navs/Types.fsi
@@ -40,6 +40,7 @@ type NavigationError<'View> =
   | NavigationFailed of message: string
   | CantDeactivate of deactivatedRoute: string
   | CantActivate of activatedRoute: string
+  | GuardRedirect of redirectTo: string
 
 [<Struct>]
 type NavigationState =
@@ -142,10 +143,15 @@ type IRouter<'View> =
   /// </remarks>
   abstract member ContentSnapshot: 'View voption
 
+[<Struct>]
+type GuardResponse =
+  | Continue
+  | Stop
+  | Redirect of url: string
 
 /// An alias for a function that takes a route context and a cancellation token
 /// In order to determine if the route can be activated/deactivated or not.
-type RouteGuard = RouteContext -> CancellationToken -> Task<bool>
+type RouteGuard<'View> = RouteContext -> INavigable<'View> -> CancellationToken -> Task<GuardResponse>
 
 /// An alias for a function that takes a route context and a cancellation token
 /// in order to extract the view that will be rendered when the route is activated.
@@ -181,11 +187,11 @@ type RouteDefinition<'View> =
     /// The guards that will be executed when the route is activated.
     /// If any of them returns false, the route will not be activated.
     [<CompiledName "CanActivate">]
-    canActivate: RouteGuard list
+    canActivate: RouteGuard<'View> list
     /// The guards that will be executed when the route is deactivated.
     /// If any of them returns false, the route will not be deactivated.
     [<CompiledName "CanDeactivate">]
-    canDeactivate: RouteGuard list
+    canDeactivate: RouteGuard<'View> list
     /// The strategy that the router will use to cache the views that are rendered
     /// when the route is activated.
     [<CompiledName "CacheStrategy">]

--- a/tests/Navs.Tests/DSL.fs
+++ b/tests/Navs.Tests/DSL.fs
@@ -19,8 +19,9 @@ module Routes =
 
   [<Tests>]
   let tests =
-    testList "Navs Route Tests" [
-      testTask "define<View> should the correct route definition<view>" {
+    testList "Navs Route DSL Tests" [
+      testCaseTask "define<View> should the correct route definition<view> sync"
+      <| fun () -> task {
         let route = Route.define("home", "/", (fun _ _ -> "Home"))
 
         let expected = {
@@ -48,8 +49,9 @@ module Routes =
         Expect.equal actual expected "GetContent should be equal"
       }
 
-      testTask
-        "define<view> should create the correct route definition<view> Async" {
+      testCaseTask
+        "define<view> should create the correct route definition<view> Async"
+      <| fun () -> task {
         let route =
           Route.define<string>(
             "home",
@@ -83,8 +85,9 @@ module Routes =
 
       }
 
-      testTask
-        "define<view> should create the correct route definition<view> Task" {
+      testCaseTask
+        "define<view> should create the correct route definition<view> Task"
+      <| fun () -> task {
         let route =
           Route.define<string>(
             "home",
@@ -118,7 +121,3 @@ module Routes =
       }
 
     ]
-
-
-[<Tests>]
-let tests = testList "Navs DSL Tests" [ Routes.tests ]

--- a/tests/Navs.Tests/Navs.Tests.fsproj
+++ b/tests/Navs.Tests/Navs.Tests.fsproj
@@ -10,7 +10,7 @@
     <Compile Include="Main.fs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Expecto" Version="10.1.0" />
+    <PackageReference Include="Expecto" Version="10.2.1" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.14.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>

--- a/tests/Navs.Tests/Router.fs
+++ b/tests/Navs.Tests/Router.fs
@@ -15,7 +15,7 @@ open UrlTemplates.RouteMatcher
 
 module NavigationState =
 
-  let tests =
+  let tests () =
     testList "NavigationState tests" [
       test "State should be Idle by default" {
         let router = Router.get<string>([], (fun _ -> "Splash"))
@@ -25,7 +25,8 @@ module NavigationState =
         Expect.equal state Idle "State should be Idle"
       }
 
-      testTask "State should be Navigating when navigating" {
+      testCaseTask "State should be Navigating when navigating"
+      <| fun () -> task {
         let routes = [
           Route.define<string>(
             "home",
@@ -65,9 +66,10 @@ module RouteContext =
   open System.Threading.Tasks
 
 
-  let tests =
+  let tests () =
     testList "RouteContext tests" [
-      testTask "RouteContext should contain the path" {
+      testCaseTask "RouteContext should contain the path"
+      <| fun () -> task {
         let router =
           Router.get<string>(
             [
@@ -96,7 +98,8 @@ module RouteContext =
         Expect.equal context.path "/about" "Path should be /about"
       }
 
-      testTask "Context should be none if navigation is cancelled or fails" {
+      ptestCaseTask "Context should be none if navigation is cancelled or fails"
+      <| fun () -> task {
         let router =
           Router.get(
             [
@@ -150,7 +153,7 @@ module RouteContext =
 
 module Navigation =
 
-  let tests =
+  let tests () =
     testList "Navs Navigation Tests" [
 
       test "Router is initialized without any views" {
@@ -171,7 +174,8 @@ module Navigation =
         Expect.equal "Splash" view "View should be Splash"
       }
 
-      testTask "The view should be updated when the route changes" {
+      testCaseTask "The view should be updated when the route changes"
+      <| fun () -> task {
         let routes = [ Route.define("home", "/", (fun _ _ -> "Home")) ]
 
         let router = Router.get<string>(routes, (fun _ -> "Splash"))
@@ -186,7 +190,8 @@ module Navigation =
         Expect.equal view "Home" "View should be Home"
       }
 
-      testTask "The view should be the fallback if not found" {
+      testCaseTask "The view should be the fallback if not found"
+      <| fun () -> task {
         let routes = [ Route.define("home", "/", (fun _ _ -> "Home")) ]
 
         let router = Router.get<string>(routes, (fun _ -> "Splash"))
@@ -205,7 +210,9 @@ module Navigation =
 
       }
 
-      testTask "The view should change any time there's a successful navigation" {
+      testCaseTask
+        "The view should change any time there's a successful navigation"
+      <| fun () -> task {
 
         let routes = [
           Route.define("home", "/", (fun _ _ -> "Home"))
@@ -230,7 +237,8 @@ module Navigation =
         Expect.equal secondNavigation "Home" "Second navigation should be Home"
       }
 
-      testTask "Children can be navigated" {
+      testCaseTask "Children can be navigated"
+      <| fun () -> task {
         let routes = [
           Route.define("users", "/users", (fun _ _ -> "Users"))
           |> Route.child(
@@ -269,9 +277,11 @@ module Navigation =
 
 module Guards =
 
-  let tests =
+  let tests () =
     testList "Guard Tests" [
-      testTask "Attempting to activate fails if canActivate returns false" {
+      testCaseTask
+        $"Attempting to activate fails if canActivate returns {nameof Stop}"
+      <| fun () -> task {
         let routes = [
           Route.define("home", "/", (fun _ _ -> "Home"))
           |> Route.canActivate((fun _ -> async { return false }))
@@ -289,10 +299,12 @@ module Guards =
 
       }
 
-      testTask "Attempting to activate succeeds if canActivate returns true" {
+      testCaseTask
+        $"Attempting to activate succeeds if canActivate returns {nameof Continue}"
+      <| fun () -> task {
         let routes = [
           Route.define("home", "/", (fun _ _ -> "Home"))
-          |> Route.canActivate((fun _ -> async { return true }))
+          |> Route.canActivate((fun _ _ -> async { return Continue }))
         ]
 
         let router = Router.get<string>(routes, (fun _ -> "Splash"))
@@ -308,8 +320,9 @@ module Guards =
         Expect.equal view "Home" "View should be Home"
       }
 
-      testTask
-        "Attempting to navigate away fails if canDeactivate returns false" {
+      testCaseTask
+        $"Attempting to navigate away fails if canDeactivate returns {nameof Stop}"
+      <| fun () -> task {
         let routes = [
           Route.define("home", "/", (fun _ _ -> "Home"))
           |> Route.canDeactivate((fun _ -> async { return false }))
@@ -334,8 +347,9 @@ module Guards =
 
       }
 
-      testTask
-        "Attempting to navigate away succeeds if canDeactivate returns true" {
+      testCaseTask
+        $"Attempting to navigate away succeeds if canDeactivate returns {nameof Continue}"
+      <| fun () -> task {
         let routes = [
           Route.define("home", "/", (fun _ _ -> "Home"))
           |> Route.canDeactivate((fun _ -> async { return true }))
@@ -357,7 +371,8 @@ module Guards =
         Expect.equal view "About" "View should be About"
       }
 
-      testTask "Parent Guard can prevent child activation" {
+      testCaseTask "Parent Guard can prevent child activation"
+      <| fun () -> task {
         let routes = [
           Route.define("users", "/users", (fun _ _ -> "Users"))
           |> Route.canActivate((fun _ -> async { return false }))
@@ -390,7 +405,8 @@ module Guards =
         Expect.equal definition "users" "Definition name should be users"
       }
 
-      testTask "Parent Guard can allow child activation" {
+      testCaseTask "Parent Guard can allow child activation"
+      <| fun () -> task {
         let routes = [
           Route.define("users", "/users", (fun _ _ -> "Users"))
           |> Route.canActivate((fun _ -> async { return true }))
@@ -421,7 +437,8 @@ module Guards =
         Expect.equal view "User - 1" "View should be User - 1"
       }
 
-      testTask "Child Guard can prevent deactivation" {
+      testCaseTask "Child Guard can prevent deactivation"
+      <| fun () -> task {
         let routes = [
           Route.define("users", "/users", (fun _ _ -> "Users"))
           |> Route.child(
@@ -460,10 +477,11 @@ module Cancellation =
   open System.Threading
   open System.Threading.Tasks
 
-  let tests =
+  let tests () =
     testList "Navigation cancellation tests" [
 
-      testTask "Navigation can be cancelled" {
+      testCaseTask "Navigation can be cancelled"
+      <| fun () -> task {
         let routes = [
           Route.define<string>(
             "home",
@@ -495,7 +513,8 @@ module Cancellation =
 
       }
 
-      testTask "Navigation can be cancelled while checking a guard" {
+      testCaseTask "Navigation can be cancelled while checking a guard"
+      <| fun () -> task {
 
         let routes = [
           Route.define<string>(
@@ -506,7 +525,7 @@ module Cancellation =
               return "Home"
             }
           )
-          |> Route.canActivate(fun _ -> async {
+          |> Route.canActivate(fun _ _ -> async {
             do! Async.Sleep 5000
             return true
           })
@@ -531,7 +550,8 @@ module Cancellation =
 
       }
 
-      testTask "Route Token can cance inner navigations" {
+      testCaseTask "Route Token can cance inner navigations"
+      <| fun () -> task {
         let mutable count = 0
 
         let routes = [
@@ -578,8 +598,9 @@ module Cancellation =
         cts.Dispose()
 
       }
-      testTask
-        "Navigations are successful and inner navigations can be cancelled" {
+      testCaseTask
+        "Navigations are successful and inner navigations can be cancelled"
+      <| fun () -> task {
         let mutable count = 0
 
         let routes = [
@@ -644,7 +665,9 @@ module Cancellation =
 
       }
 
-      testTask "Navigation completes before cancellation and it doesn't throw" {
+      testCaseTask
+        "Navigation completes before cancellation and it doesn't throw"
+      <| fun () -> task {
         let routes = [
           Route.define<string>(
             "home",
@@ -673,10 +696,12 @@ module Cancellation =
         cts.Dispose()
       }
 
-      testTask "Navigation can be cancelled while checking deactivate guards" {
+      testCaseTask
+        "Navigation can be cancelled while checking deactivate guards"
+      <| fun () -> task {
         let routes = [
           Route.define<string>("home", "/", (fun _ _ -> "Home"))
-          |> Route.canDeactivate(fun _ -> async {
+          |> Route.canDeactivate(fun _ _ -> async {
             do! Async.Sleep 5000
             return true
           })
@@ -708,9 +733,9 @@ module Cancellation =
 [<Tests>]
 let tests =
   testList "Navs Router Tests" [
-    NavigationState.tests
-    RouteContext.tests
-    Navigation.tests
-    Guards.tests
-    Cancellation.tests
+    NavigationState.tests()
+    RouteContext.tests()
+    Navigation.tests()
+    Guards.tests()
+    Cancellation.tests()
   ]


### PR DESCRIPTION
Allow Guards to Continue, Stop (previously true/false) or Redirect (added) for CanActivate

CanDeactivate guards share the same type but CanDeactivate is not going to be respected in this PR because there's more complications related to skip the Can Deactivate guard that triggered this on the current shitty design I have, and also I'm not sure how useful CanDeactivate redirects are for this case.